### PR TITLE
Fix unexpected RuntimeException from Tika because of missing Xerces in bundles

### DIFF
--- a/extractous-core/tika-native/src/main/resources/META-INF/ai.yobix/tika-2.9.2-linux/reachability-metadata.json
+++ b/extractous-core/tika-native/src/main/resources/META-INF/ai.yobix/tika-2.9.2-linux/reachability-metadata.json
@@ -17,6 +17,13 @@
                 "en-US"
             ],
             "name": "sun.awt.resources.awt"
+        },
+        {
+            "locales": [
+                "en", 
+                "en-US"
+            ],
+            "name": "org.apache.xerces.impl.msg.XMLMessages"
         }
     ],
     "jni": [

--- a/extractous-core/tika-native/src/main/resources/META-INF/ai.yobix/tika-2.9.2-macos/reachability-metadata.json
+++ b/extractous-core/tika-native/src/main/resources/META-INF/ai.yobix/tika-2.9.2-macos/reachability-metadata.json
@@ -23,6 +23,13 @@
                 "en-GB"
             ],
             "name": "sun.awt.resources.awtosx"
+        },
+        {
+            "locales": [
+                "en", 
+                "en-US"
+            ],
+            "name": "org.apache.xerces.impl.msg.XMLMessages"
         }
     ],
     "jni": [

--- a/extractous-core/tika-native/src/main/resources/META-INF/ai.yobix/tika-2.9.2-windows/reachability-metadata.json
+++ b/extractous-core/tika-native/src/main/resources/META-INF/ai.yobix/tika-2.9.2-windows/reachability-metadata.json
@@ -17,6 +17,13 @@
                 "en-US"
             ],
             "name": "sun.awt.resources.awt"
+        },
+        {
+            "locales": [
+                "en", 
+                "en-US"
+            ],
+            "name": "org.apache.xerces.impl.msg.XMLMessages"
         }
     ],
     "jni": [


### PR DESCRIPTION
This implements the solution proposed by @titusz in a comment of issue #56.

I'm not an expert of GraalVM, but according to my tests it solves the error I used to get on many PDFs.