### PR TITLE
fix: drop AttachGuard only after all GlobalRefs in JReaderInputStream are dropped

### DIFF
--- a/extractous-core/Cargo.toml
+++ b/extractous-core/Cargo.toml
@@ -16,6 +16,9 @@ readme = "README.md"
 keywords = ["unstructured", "tika", "text", "pdf", "parser"]
 categories = ["parsing", "text-processing"]
 
+[features]
+stream-attachguard = []
+
 [[bench]]
 name = "extractor"
 harness = false
@@ -23,9 +26,9 @@ required-features = []
 
 [dependencies]
 libc = { version = "0.2.158" }
-jni = { version = "0.21.1",features = ["invocation"] }
+jni = { version = "0.21.1", features = ["invocation"] }
 thiserror = { version = "1.0.63" }
-bytemuck =  { version = "1.17.1"}
+bytemuck = { version = "1.17.1" }
 # String enums
 strum = { version = "0.26.2" }
 strum_macros = { version = "0.26.2" }

--- a/extractous-core/benches/extractor.rs
+++ b/extractous-core/benches/extractor.rs
@@ -10,7 +10,7 @@ fn extract_to_stream(c: &mut Criterion) {
     c.bench_function("extract_to_stream", |b| {
         b.iter(|| {
             // Extract the provided file content to a stream
-            let stream = extractor.extract_file(file_path).unwrap();
+            let (stream, _) = extractor.extract_file(file_path).unwrap();
             // Because stream implements std::io::Read trait we can perform buffered reading
             // For example we can use it to create a BufReader
             let mut reader = BufReader::new(stream);

--- a/extractous-core/src/extractor.rs
+++ b/extractous-core/src/extractor.rs
@@ -36,7 +36,7 @@ pub enum CharSet {
 /// ```
 ///
 pub struct StreamReader {
-    pub(crate) inner: JReaderInputStream<'static>,
+    pub(crate) inner: JReaderInputStream,
 }
 
 impl std::io::Read for StreamReader {

--- a/extractous-core/src/extractor.rs
+++ b/extractous-core/src/extractor.rs
@@ -36,7 +36,7 @@ pub enum CharSet {
 /// ```
 ///
 pub struct StreamReader {
-    pub(crate) inner: JReaderInputStream,
+    pub(crate) inner: JReaderInputStream<'static>,
 }
 
 impl std::io::Read for StreamReader {
@@ -202,7 +202,6 @@ impl Extractor {
             self.xml_output,
         )
     }
-
 }
 
 #[cfg(test)]

--- a/extractous-core/src/tika/parse.rs
+++ b/extractous-core/src/tika/parse.rs
@@ -18,7 +18,7 @@ pub(crate) fn vm() -> &'static JavaVM {
     GRAAL_VM.get_or_init(create_vm_isolate)
 }
 
-fn get_vm_attach_current_thread<'local>() -> ExtractResult<AttachGuard<'local>> {
+fn get_vm_attach_current_thread() -> ExtractResult<AttachGuard<'static>> {
     // Attaching a thead that is already attached is a no-op. Good to have this in case this method
     // is called from another thread
     let env = vm().attach_current_thread()?;
@@ -26,7 +26,7 @@ fn get_vm_attach_current_thread<'local>() -> ExtractResult<AttachGuard<'local>> 
 }
 
 fn parse_to_stream(
-    mut env: AttachGuard,
+    mut env: AttachGuard<'static>,
     data_source_val: JValue,
     char_set: &CharSet,
     pdf_conf: &PdfParserConfig,
@@ -60,7 +60,7 @@ fn parse_to_stream(
 
     // Create and process the JReaderResult
     let result = JReaderResult::new(&mut env, call_result_obj)?;
-    let j_reader = JReaderInputStream::new(&mut env, result.java_reader)?;
+    let j_reader = JReaderInputStream::new(env, result.java_reader)?;
 
     Ok((StreamReader { inner: j_reader }, result.metadata))
 }
@@ -71,7 +71,7 @@ pub fn parse_file(
     pdf_conf: &PdfParserConfig,
     office_conf: &OfficeParserConfig,
     ocr_conf: &TesseractOcrConfig,
-    as_xml: bool
+    as_xml: bool,
 ) -> ExtractResult<(StreamReader, Metadata)> {
     let mut env = get_vm_attach_current_thread()?;
 


### PR DESCRIPTION
Hi, thanks for the library!

When using the Streams for text extraction, `GlobalRef`s are dropped after the thread is already detached from the VM. This leads to a warning from jni crate:

> Dropping a GlobalRef in a detached thread. Fix your code if this message appears frequently (see the GlobalRef docs).

I fixed this by including the `AttachGuard` in the `JReaderInputStream` struct, so that the thread is detached only after all GlobalRefs in it are dropped.

(also, the tagged v0.3.0 commit is not part of any branch in this repository and main is outdated)